### PR TITLE
Added "typings" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.10",
   "description": "TypeScript decorators based wrapper over mocha's interface",
   "main": "index.js",
+  "typings": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/PanayotCankov/mocha-typescript"


### PR DESCRIPTION
Without the `typings` property, the typescript compiler (v2.0.3) does not find this module.
Adding this property fixed the problem for me.