### PR TITLE
Forward all unparsed parameters of watch script to mocha

### DIFF
--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -68,7 +68,8 @@ function compilationComplete() {
         console.log(chalk.gray("Run mocha."));
     }
 
-    mocha = spawn("node", [argv.mocha, "--opts", argv.opts, "--colors"]);
+    var mocha_options = ["--opts", argv.opts, "--colors"].concat(argv._);
+    mocha = spawn("node", [argv.mocha].concat(mocha_options));
     mocha.on("close", code => {
         if (code) {
             console.log(chalk.red("Exited with " + code));


### PR DESCRIPTION
This can be used to submit the 'files' argument to mocha when
testing from a non default location.

(Should fix #15)